### PR TITLE
Fix Django urls import error

### DIFF
--- a/webyb_2/urls.py
+++ b/webyb_2/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import path
-from django.conf.urls import include, url
+from django.urls import include
 from django.conf import settings
 from django.conf.urls.static import static
 


### PR DESCRIPTION
## Summary
- update deprecated import in `urls.py`

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6845c308f5ac832487dc9288c8b4f467